### PR TITLE
Fix TX series pawns and force hostile reboots

### DIFF
--- a/Source/AndroidResurrectionKit/JobDriver_ResurrectAndroid.cs
+++ b/Source/AndroidResurrectionKit/JobDriver_ResurrectAndroid.cs
@@ -71,17 +71,18 @@ namespace AndroidResurrectionKit
             Pawn innerPawn = this.Corpse.InnerPawn;
 
             bool canResurrect = false;
-            string deadPawnRaceName = innerPawn.kindDef.race.defName.ToLower();
+            ThingDef race = innerPawn.kindDef.race;
+            string deadPawnRaceName = race.defName;
             switch (Item.def.defName)
             {
                 case "RepairKitResurrectorB":
-                    canResurrect = deadPawnRaceName.Contains("1tier");
+                    canResurrect = deadPawnRaceName == "Android1Tier";
                     break;
                 case "RepairKitResurrectorA":
-                    canResurrect = deadPawnRaceName.Contains("1tier") || deadPawnRaceName.Contains("2tier");
+                    canResurrect = deadPawnRaceName == "Android1Tier" || deadPawnRaceName == "Android2Tier" || deadPawnRaceName.StartsWith("ATPP_Android2");
                     break;
                 case "RepairKitResurrectorS":
-                    canResurrect = deadPawnRaceName.Contains("android");
+                    canResurrect = deadPawnRaceName.ToLower().Contains("android") || race.label.ToLower().Contains("android") || deadPawnRaceName == "M7Mech";
                     break;
             }
 

--- a/Source/AndroidResurrectionKit/JobDriver_ResurrectAndroid.cs
+++ b/Source/AndroidResurrectionKit/JobDriver_ResurrectAndroid.cs
@@ -89,6 +89,15 @@ namespace AndroidResurrectionKit
             if (canResurrect)
             {
                 ResurrectionUtility.Resurrect(innerPawn);
+
+                // If hostile, force it to reboot, so that it can be captured and reprogrammed
+                if (innerPawn.Faction != null && innerPawn.Faction != Faction.OfPlayer && innerPawn.HostileTo(Faction.OfPlayer)) {
+                    HediffDef rebootHediffDef = DefDatabase<HediffDef>.GetNamed("RebootingSequenceAT");
+                    Hediff hediff = HediffMaker.MakeHediff(rebootHediffDef, innerPawn);
+                    hediff.Severity = 1f;
+                    innerPawn.health.AddHediff(hediff);
+                }
+
                 Messages.Message("MessagePawnResurrected".Translate(innerPawn).CapitalizeFirst(), innerPawn, MessageTypeDefOf.PositiveEvent, true);
                 this.Item.SplitOff(1).Destroy(DestroyMode.Vanish);
             }


### PR DESCRIPTION
Here's a couple of fixes:

1. Adds support to the [TX series](https://steamcommunity.com/sharedfiles/filedetails/?id=2010528561) androids for A-tier kits, as well as the M7 Mech for S-Tier from the base mod.

2. If the ressed pawn is hostile, it'll install a reboot cycle hediff onto the pawn to give the user a chance to capture and reprogram it.